### PR TITLE
🐛  fix: Input not focus on page load

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -48,7 +48,9 @@
   reset()
 
   onMount(() => {
-    typingInput.focus()
+    setTimeout(() => {
+      typingInput.focus()
+    }, 500)
   })
 
   $: wpm = calculateWpm(correctWords, elapsed).toFixed(1)


### PR DESCRIPTION
# Description

- Add `setTimeout()` on `onMount()` to guaranteed input will autofocus when load page

Fixes [Input not autofocus on page load #15](https://github.com/Manoonchai/learn/issues/15)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)