### PR TITLE
feat(keymap): align rows like a physical board and recolor shift cue

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -6,8 +6,9 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* ---- Semantic palette (OKLCH). The mood lives in the brand colors, not the
-   surface: a cool graphite instrument with a teal "indicator" primary and a
-   terracotta "achievement" accent reserved for the climax of a drill. ---- */
+   surface: a cool graphite instrument with a teal "indicator" primary, a
+   terracotta "achievement" accent reserved for the climax of a drill, and a
+   violet "shift" cue for keys that need the Shift modifier. ---- */
 :root {
   --bg: oklch(1 0 0);
   --surface: oklch(0.976 0.003 240);
@@ -22,6 +23,7 @@
   --primary-ink: oklch(0.99 0.005 215);
   --accent: oklch(0.6 0.15 41);
   --accent-ink: oklch(0.99 0.01 41);
+  --shift: oklch(0.55 0.16 293);
   --danger: oklch(0.54 0.2 25);
   --danger-ink: oklch(0.99 0.01 25);
 
@@ -42,6 +44,7 @@
   --primary-ink: oklch(0.16 0.02 240);
   --accent: oklch(0.74 0.15 46);
   --accent-ink: oklch(0.18 0.03 46);
+  --shift: oklch(0.76 0.16 295);
   --danger: oklch(0.71 0.18 25);
   --danger-ink: oklch(0.16 0.03 25);
 
@@ -64,6 +67,7 @@
   --color-primary-ink: var(--primary-ink);
   --color-accent: var(--accent);
   --color-accent-ink: var(--accent-ink);
+  --color-shift: var(--shift);
   --color-danger: var(--danger);
   --color-danger-ink: var(--danger-ink);
 
@@ -119,6 +123,12 @@
       0 0 0 1px var(--accent),
       0 0 14px -2px var(--accent),
       0 0 26px -8px var(--accent);
+  }
+  .glow-shift {
+    box-shadow:
+      0 0 0 1px var(--shift),
+      0 0 14px -2px var(--shift),
+      0 0 26px -8px var(--shift);
   }
 
   /* A slow breathing pulse on the live cursor so the eye finds it. */

--- a/apps/web/src/lib/components/Key.svelte
+++ b/apps/web/src/lib/components/Key.svelte
@@ -16,7 +16,7 @@
     {activeBase
     ? `border-primary bg-primary/12 -translate-y-px ${glow ? 'glow-primary' : ''}`
     : activeShift
-      ? `border-accent bg-accent/12 -translate-y-px ${glow ? 'glow-accent' : ''}`
+      ? `border-shift bg-shift/12 -translate-y-px ${glow ? 'glow-shift' : ''}`
       : 'border-border bg-panel'}"
   data-code={keyData.code}
   data-active={activeBase || activeShift ? "true" : undefined}
@@ -24,7 +24,7 @@
   {#if keyData.shift}
     <span
       class="absolute top-0.5 right-1 text-[0.62em] leading-none
-        {activeShift ? 'text-accent' : 'text-faint'}"
+        {activeShift ? 'text-shift' : 'text-faint'}"
     >
       {keyData.shift}
     </span>

--- a/apps/web/src/lib/components/Keymap.svelte
+++ b/apps/web/src/lib/components/Keymap.svelte
@@ -6,62 +6,76 @@
 
   const shiftActive = $derived(isShifted(nextChar));
   const spaceActive = $derived(nextChar === " ");
+
+  // Non-functional modifier caps that frame each row. They flex-grow equally so
+  // every row fills the same width — left and right edges line up, and their
+  // differing widths (Tab < Caps < Shift) produce the physical-keyboard stagger.
+  const ROW_MODS = [
+    { left: "Tab", right: "", shift: false },
+    { left: "Caps Lock", right: "Enter", shift: false },
+    { left: "Shift", right: "Shift", shift: true },
+  ];
 </script>
 
-<div class="keymap mx-auto w-full max-w-2xl select-none" aria-hidden="true">
-  <!-- Letter rows, staggered like a physical board. -->
-  <div class="flex flex-col gap-[var(--g)]">
-    {#each LAYOUT_ROWS as row, r (r)}
-      <div
-        class="flex gap-[var(--g)]"
-        style={r === 1 ? "padding-left: calc(var(--u) * 0.5)" : ""}
-      >
-        {#if r === 2}
-          <div
-            class="key-cap grid place-items-center rounded-md border text-[0.62em] font-medium tracking-wide transition-colors duration-150
-              {shiftActive ? 'border-accent bg-accent/12 text-accent' : 'border-border bg-panel text-faint'}"
-            style="width: calc(var(--u) * 1.6); font-size: calc(var(--u) * 0.42)"
-          >
-            <span style="font-size: 0.62em">SHIFT</span>
-          </div>
-        {/if}
-        {#each row as key (key.code)}
-          <div class="key-slot" style="width: var(--u); font-size: calc(var(--u) * 0.46)">
-            <Key keyData={key} {nextChar} {glow} />
-          </div>
-        {/each}
-        {#if r === 2}
-          <div
-            class="key-cap grid place-items-center rounded-md border text-[0.62em] font-medium tracking-wide transition-colors duration-150
-              {shiftActive ? 'border-accent bg-accent/12 text-accent' : 'border-border bg-panel text-faint'}"
-            style="width: calc(var(--u) * 1.6); font-size: calc(var(--u) * 0.42)"
-          >
-            <span style="font-size: 0.62em">SHIFT</span>
-          </div>
-        {/if}
-      </div>
-    {/each}
+{#snippet cap(label: string, shift: boolean)}
+  <div
+    class="grid place-items-center overflow-hidden rounded-md border font-medium uppercase tracking-wide transition-colors duration-150
+      {shift && shiftActive ? 'border-shift bg-shift/12 text-shift' : 'border-border bg-panel text-faint'}"
+    style="flex: 1 1 0; min-width: 0; font-size: calc(var(--u) * 0.34)"
+  >
+    <span class="truncate px-1" style="font-size: 0.62em">{label}</span>
   </div>
+{/snippet}
 
-  <!-- Spacebar -->
-  <div class="mt-[var(--g)] flex justify-center">
-    <div
-      class="grid h-[calc(var(--u)*0.72)] place-items-center rounded-md border transition-[background-color,border-color,box-shadow] duration-150
-        {spaceActive
-        ? `border-primary bg-primary/12 ${glow ? 'glow-primary' : ''}`
-        : 'border-border bg-panel'}"
-      style="width: calc(var(--u) * 7)"
-    >
-      <span class="text-[0.62rem] tracking-[0.3em] {spaceActive ? 'text-primary' : 'text-faint'}">
-        SPACE
-      </span>
+<div class="keymap mx-auto select-none" aria-hidden="true">
+  <div class="keys">
+    <!-- Letter rows, framed by placeholder modifiers like a physical board. -->
+    <div class="flex flex-col gap-[var(--g)]">
+      {#each LAYOUT_ROWS as row, r (r)}
+        <div class="flex gap-[var(--g)]">
+          {@render cap(ROW_MODS[r].left, ROW_MODS[r].shift)}
+          {#each row as key (key.code)}
+            <div class="key-slot shrink-0" style="width: var(--u); font-size: calc(var(--u) * 0.46)">
+              <Key keyData={key} {nextChar} {glow} />
+            </div>
+          {/each}
+          {#if ROW_MODS[r].right}
+            {@render cap(ROW_MODS[r].right, ROW_MODS[r].shift)}
+          {/if}
+        </div>
+      {/each}
+    </div>
+
+    <!-- Spacebar -->
+    <div class="mt-[var(--g)] flex justify-center">
+      <div
+        class="grid h-[calc(var(--u)*0.72)] place-items-center rounded-md border transition-[background-color,border-color,box-shadow] duration-150
+          {spaceActive
+          ? `border-primary bg-primary/12 ${glow ? 'glow-primary' : ''}`
+          : 'border-border bg-panel'}"
+        style="width: calc(var(--u) * 7)"
+      >
+        <span class="text-[0.62rem] tracking-[0.3em] {spaceActive ? 'text-primary' : 'text-faint'}">
+          SPACE
+        </span>
+      </div>
     </div>
   </div>
 </div>
 
 <style>
+  /* The board is a size container; every key is sized in cqw off this width,
+     so keys stay identical across rows at any viewport and columns never drift. */
   .keymap {
-    --u: clamp(1.9rem, 5.6vw, 3.1rem);
-    --g: clamp(0.18rem, 0.7vw, 0.4rem);
+    container-type: inline-size;
+    width: min(100%, 48rem);
+  }
+
+  /* Widest content is the top row: Tab + 13 keys + 13 gaps. With the side caps
+     flex-growing to fill each row, dividing the board width by 16.25u lands the
+     top→home stagger at 0.25u (and home→bottom at the exact half-key pitch). */
+  .keys {
+    --u: calc(100cqw / 16.25);
+    --g: calc(var(--u) * 0.125);
   }
 </style>

--- a/apps/web/src/lib/components/Keymap.test.ts
+++ b/apps/web/src/lib/components/Keymap.test.ts
@@ -13,7 +13,8 @@ describe("Keymap", () => {
     // ช is the shift layer of KeyF.
     const { container } = render(Keymap, { props: { nextChar: "ช", glow: false } });
     expect(container.querySelector("[data-code=KeyF]")?.getAttribute("data-active")).toBe("true");
-    expect(container.textContent).toContain("SHIFT");
+    // The cap label is "Shift" (displayed uppercase via CSS).
+    expect(container.textContent).toContain("Shift");
   });
 
   it("activates no letter key when the next key is space", () => {


### PR DESCRIPTION
## What

Polishes the on-screen Manoonchai keymap so it reads like a real staggered keyboard, and gives the Shift cue its own color.

- **Uniform keys / column alignment** — the board is now a size container and each key is sized in `cqw` off the board width, so keys are identical across all three rows at every viewport.
- **Placeholder modifier keys** — added non-functional **Tab**, **Caps Lock**, and **Enter** caps; all side caps `flex-grow` equally so both the left and right edges line up and the **Shift** keys are stretched.
- **Physical stagger** — staggering now comes from the modifier widths (Tab < Caps < Shift), giving top→home a `0.25u` offset and home→bottom an exact half-key pitch.
- **Shift recolor** — the shift highlight no longer borrows the orange `--accent`; it uses a dedicated violet `--shift` color (+ a `.glow-shift` utility) in both light and dark themes.

## Why

- The rows overflowed the fixed-width container, so `flex-shrink` resized keys **per-row** — the 11-key home row stayed wide while the 13- and 12-key rows shrank. The unequal widths accumulated drift, so e.g. `ก` sat over `า` instead of `่`.
- The bottom row led with an oversized 1.6u SHIFT cap, pushing its keys past the natural half-key stagger (so `ุ` wasn't centered between `ง` and `เ`).
- `--accent` is the terracotta "achievement" color reserved for the drill-climax Net WPM readout (number + chart line); reusing it for Shift muddied that meaning.

## Reviewer notes

- The cqw divisor `16.25` is chosen so that, with the side caps flex-growing equally to fill each row, the top→home stagger lands at exactly `0.25u` (home→bottom is half-pitch regardless of the divisor). See the comment in `Keymap.svelte`.
- `--shift` is a new semantic token; `--accent` is intentionally left in place for `WpmChart` and `DrillSummary`.
- Verified live (desktop + 375px mobile): keys uniform, both edges flush, `ุ`/`ู` centered on their home-row midpoints, no horizontal overflow, and the shift highlight renders violet in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)