### PR TITLE
Fix settings icon looking like a brightness/sun icon

### DIFF
--- a/apps/web/src/lib/components/WpmChart.svelte
+++ b/apps/web/src/lib/components/WpmChart.svelte
@@ -31,14 +31,14 @@
         x="second"
         y={["raw", "net"]}
         yNice
-        padding={{ left: 34, bottom: 26, top: 8, right: 10 }}
+        padding={{ left: 48, bottom: 40, top: 8, right: 10 }}
         let:xScale
         let:yScale
       >
         <Svg>
           <Grid y class="grid-line" />
-          <Axis placement="left" rule={false} />
-          <Axis placement="bottom" rule={false} />
+          <Axis placement="left" rule={false} label="WPM" />
+          <Axis placement="bottom" rule={false} label="วินาที" />
           <Spline y="raw" class="line-raw" {draw} />
           <Spline y="net" class="line-net" {draw} />
           {#each errorPoints as p (p.second)}
@@ -84,6 +84,18 @@
     font-family: var(--font-mono);
     font-size: 0.68rem;
     font-weight: 400;
+  }
+  /* Axis titles ("WPM" / "วินาที"). LayerChart's default `.label` class pulls
+     svelte-ux utilities (`stroke-surface-100`, …) that don't exist here, so
+     pin them to our tokens — otherwise they render with a stray halo / wrong
+     colour. */
+  .chart :global(.label) {
+    fill: var(--faint);
+    stroke: none;
+    font-family: var(--font-thai);
+    font-size: 0.66rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
   }
   .chart :global(.grid-line line),
   .chart :global(.rule line),

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -232,13 +232,14 @@
         aria-label="ตั้งค่า"
       >
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <circle cx="12" cy="12" r="3.2" stroke="currentColor" stroke-width="1.7" />
           <path
-            d="M12 2.8v2M12 19.2v2M21.2 12h-2M4.8 12h-2M18.5 5.5l-1.4 1.4M6.9 17.1l-1.4 1.4M18.5 18.5l-1.4-1.4M6.9 6.9 5.5 5.5"
+            d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z"
             stroke="currentColor"
             stroke-width="1.7"
             stroke-linecap="round"
+            stroke-linejoin="round"
           />
+          <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="1.7" />
         </svg>
       </button>
     </div>


### PR DESCRIPTION
The settings (ตั้งค่า) button used a circle-with-radial-spokes SVG that
read as a sun/brightness icon — nearly identical to the light-theme sun on
the adjacent ThemeToggle. Replace it with a proper gear/cog icon so it
clearly reads as settings.