### PR TITLE
fix(result): show wpm y-axis on both charts and open up share-card layout

### DIFF
--- a/apps/web/src/lib/components/WpmChart.svelte
+++ b/apps/web/src/lib/components/WpmChart.svelte
@@ -37,7 +37,7 @@
       >
         <Svg>
           <Grid y class="grid-line" />
-          <Axis placement="left" rule={false} label="WPM" />
+          <Axis placement="left" rule={false} label="wpm" labelProps={{ x: -36 }} />
           <Axis placement="bottom" rule={false} label="วินาที" />
           <Spline y="raw" class="line-raw" {draw} />
           <Spline y="net" class="line-net" {draw} />
@@ -96,6 +96,15 @@
     font-size: 0.66rem;
     font-weight: 500;
     letter-spacing: 0.02em;
+  }
+  /* LayerChart's Text wraps every tick/axis label in a nested <svg> and leans
+     on a `.overflow-visible` utility (svelte-ux) to stop the SVG default
+     `overflow: hidden` from clipping glyphs that sit at negative coords — the
+     left axis is anchored `end` at x=0 and the rotated "wpm" title sits at
+     negative x. That utility isn't generated here, so without this the whole
+     y-axis (ticks + title) gets clipped away. Pin overflow to our intent. */
+  .chart :global(svg) {
+    overflow: visible;
   }
   .chart :global(.grid-line line),
   .chart :global(.rule line),

--- a/apps/web/src/lib/share/result-card.ts
+++ b/apps/web/src/lib/share/result-card.ts
@@ -32,13 +32,14 @@ export function shareFilename(d: ShareData): string {
 }
 
 const W = 1200;
-const MARGIN = 72;
-const TOP_H = 560; // title + big wpm + chart + stats block
-const FOOTER_H = 64; // footer baseline sits at height − 36
-const HIST_TITLE_DY = 34; // input-history title baseline below TOP_H
-const HIST_FIRST_DY = 84; // first word line baseline below TOP_H
-const HIST_LINE_H = 44;
-const HIST_PAD_BOTTOM = 24;
+const MARGIN = 80;
+const FRAME = 28; // inset of the hairline border from the canvas edge
+const TOP_H = 600; // title + big wpm + chart + stats block
+const FOOTER_H = 84; // footer baseline sits at height − 48
+const HIST_TITLE_DY = 40; // input-history title baseline below TOP_H
+const HIST_FIRST_DY = 98; // first word line baseline below TOP_H
+const HIST_LINE_H = 48;
+const HIST_PAD_BOTTOM = 36;
 const HIST_FONT_PX = 30;
 const HIST_WORD_GAP = 16; // extra px between words (Thai has no word spaces)
 const MAX_HISTORY_WORDS = 240; // bound the card height for very fast runs
@@ -142,37 +143,67 @@ function buildLegend(thresholds: number[], bucket: string[]): LegendItem[] {
   });
 }
 
-/** Mini WPM chart: raw (primary) + net (accent) lines with error dots. */
-function drawChart(
-  ctx: CanvasRenderingContext2D,
-  samples: WpmSample[],
-  colors: { primary: string; accent: string; danger: string; border: string },
-): void {
+/** Mini WPM chart: raw (primary) + net (accent) lines with error dots, framed
+ * by a labelled y-axis ("wpm" + ticks) and a light seconds x-axis. */
+function drawChart(ctx: CanvasRenderingContext2D, samples: WpmSample[], colors: Colors): void {
   if (samples.length === 0) return;
-  const left = 560;
-  const right = 1128;
-  const top = 174;
-  const bottom = 430;
+  // Plot area; a 64px gutter on the left holds the y-axis ticks + title.
+  const left = 624;
+  const right = 1120;
+  const top = 150;
+  const bottom = 392;
   const w = right - left;
   const h = bottom - top;
 
   const n = samples.length;
   const lastSecond = samples[n - 1].second;
-  const maxY = Math.max(1, ...samples.map((s) => Math.max(s.raw, s.net)));
+  const dataMax = Math.max(1, ...samples.map((s) => Math.max(s.raw, s.net)));
+  // Round the axis up to a tidy multiple of 20 so peaks keep headroom and the
+  // tick labels read as round numbers.
+  const axisMax = Math.max(20, Math.ceil(dataMax / 20) * 20);
   const x = (second: number) => (n < 2 ? left + w / 2 : left + ((second - 1) / (lastSecond - 1)) * w);
-  const y = (v: number) => bottom - (v / maxY) * h;
+  const y = (v: number) => bottom - (v / axisMax) * h;
 
-  // Faint frame: baseline + top gridline.
-  ctx.strokeStyle = colors.border;
-  ctx.globalAlpha = 0.7;
-  ctx.lineWidth = 1;
-  for (const gy of [top, bottom]) {
+  // Horizontal gridlines + y-axis tick labels at 0 / mid / max.
+  ctx.textAlign = "right";
+  ctx.textBaseline = "middle";
+  ctx.font = `500 22px ${FONT}`;
+  for (const v of [0, axisMax / 2, axisMax]) {
+    const gy = y(v);
+    ctx.strokeStyle = colors.border;
+    ctx.globalAlpha = v === 0 ? 0.8 : 0.35;
+    ctx.lineWidth = 1;
     ctx.beginPath();
     ctx.moveTo(left, gy);
     ctx.lineTo(right, gy);
     ctx.stroke();
+    ctx.globalAlpha = 1;
+    ctx.fillStyle = colors.faint;
+    ctx.fillText(String(Math.round(v)), left - 16, gy);
   }
-  ctx.globalAlpha = 1;
+
+  // Rotated "wpm" y-axis title.
+  ctx.save();
+  ctx.translate(left - 56, (top + bottom) / 2);
+  ctx.rotate(-Math.PI / 2);
+  ctx.textAlign = "center";
+  ctx.textBaseline = "alphabetic";
+  ctx.fillStyle = colors.faint;
+  ctx.font = `600 22px ${FONT}`;
+  ctx.fillText("wpm", 0, 0);
+  ctx.restore();
+
+  // Seconds x-axis ticks (quarters of the run).
+  ctx.textAlign = "center";
+  ctx.textBaseline = "top";
+  ctx.font = `500 22px ${FONT}`;
+  ctx.fillStyle = colors.faint;
+  const seconds = [...new Set([0, 0.25, 0.5, 0.75, 1].map((f) => Math.round(f * lastSecond)))];
+  for (const sec of seconds) {
+    const px = sec <= 1 ? left : Math.min(right, x(sec));
+    const last = sec === seconds[seconds.length - 1];
+    ctx.fillText(last ? `${sec}s` : String(sec), px, bottom + 16);
+  }
 
   const line = (key: "raw" | "net", stroke: string, width: number, alpha: number) => {
     ctx.strokeStyle = stroke;
@@ -253,22 +284,22 @@ function drawCard(
   ctx.fillRect(0, 0, W, height);
   ctx.strokeStyle = colors.border;
   ctx.lineWidth = 2;
-  ctx.strokeRect(24, 24, W - 48, height - 48);
+  ctx.strokeRect(FRAME, FRAME, W - 2 * FRAME, height - 2 * FRAME);
 
   ctx.textAlign = "left";
   ctx.textBaseline = "alphabetic";
 
   ctx.fillStyle = colors.muted;
   ctx.font = `600 30px ${FONT}`;
-  ctx.fillText("Learn Manoonchai · Time Attack", MARGIN, 110);
+  ctx.fillText("Learn Manoonchai · Time Attack", MARGIN, 108);
 
   ctx.fillStyle = colors.accent;
-  ctx.font = `700 210px ${FONT}`;
-  ctx.fillText(String(d.netWpm), 68, 360);
+  ctx.font = `700 188px ${FONT}`;
+  ctx.fillText(String(d.netWpm), MARGIN - 6, 360);
 
   ctx.fillStyle = colors.muted;
   ctx.font = `500 44px ${FONT}`;
-  ctx.fillText("net wpm", 76, 410);
+  ctx.fillText("net wpm", MARGIN, 414);
 
   drawChart(ctx, samples, colors);
 
@@ -278,15 +309,17 @@ function drawCard(
     ["consistency", `${d.consistency}%`],
     ["time", `${d.seconds}s`],
   ];
-  const colW = (W - 144) / stats.length;
+  const colW = (W - 2 * MARGIN) / stats.length;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "alphabetic";
   stats.forEach(([label, value], i) => {
     const x = MARGIN + i * colW;
     ctx.fillStyle = colors.ink;
     ctx.font = `700 56px ${FONT}`;
-    ctx.fillText(value, x, 498);
+    ctx.fillText(value, x, 506);
     ctx.fillStyle = colors.muted;
     ctx.font = `500 28px ${FONT}`;
-    ctx.fillText(label, x, 536);
+    ctx.fillText(label, x, 544);
   });
 
   if (lines.length > 0) drawHistory(ctx, lines, legend, colors);
@@ -294,9 +327,10 @@ function drawCard(
   ctx.fillStyle = colors.muted;
   ctx.font = `500 28px ${FONT}`;
   ctx.textAlign = "left";
-  ctx.fillText(d.date, MARGIN, height - 36);
+  ctx.textBaseline = "alphabetic";
+  ctx.fillText(d.date, MARGIN, height - 48);
   ctx.textAlign = "right";
-  ctx.fillText("learn.manoonchai.com", W - MARGIN, height - 36);
+  ctx.fillText("learn.manoonchai.com", W - MARGIN, height - 48);
 }
 
 /** Render the share card to a PNG blob (browser only). */


### PR DESCRIPTION
## Problem

Two issues on the result screen, both about the WPM chart's missing y-axis:

1. **Live chart** — the `WpmChart` markup already had a `label="WPM"` on the left axis, but it never painted. LayerChart wraps every tick/axis-title in a nested `<svg class="overflow-visible">` and depends on that utility to override the SVG default `overflow: hidden`. This project's Tailwind doesn't generate `overflow-visible` (same gap the component's `<style>` already documents for `fill-surface-content`/`stroke-surface-100`), so each nested svg fell back to `overflow: hidden` and clipped the left axis — its tick labels are anchored `end` at x=0 (glyphs at negative x) and the rotated title sits at negative x, both outside their nested viewport. The bottom axis (positive/centered x) escaped, which is why the x-label showed but the y-label didn't.

2. **Share card** (hand-drawn canvas, separate code) had no axis at all, and the overall layout felt packed with no whitespace.

## Changes

**`WpmChart.svelte`** (live chart)
- Pin `overflow: visible` on the chart's svg elements so the nested-svg clip no longer eats the y-axis.
- Nudge the rotated title into the gutter via `labelProps` (it was pinned to the container's left edge); lowercase `wpm` to match the `raw wpm` / `net wpm` captions.

**`result-card.ts`** (share PNG)
- Add a labelled **wpm** y-axis (rotated title, `0 / mid / max` tick labels, gridlines) and a light **seconds** x-axis.
- Round the axis up to a multiple of 20 so peaks keep headroom instead of clipping the top frame.
- Open up the vertical rhythm (margins, section gaps, history line height) and lighten the hero number for more whitespace.
- Reset `textAlign`/`textBaseline` after `drawChart` so the stats and footer no longer inherit the chart's centred/top text state.

## Verification

- Live chart: drove a real drill via Playwright, confirmed the `wpm` title + ticks now render (root-caused via DOM inspection — nested-svg `overflow:hidden` clip).
- Share card: rendered the real PNG through `renderResultBlob` with synthetic 60s data and iterated on the screenshot.
- `result-card` tests pass (2/2); `svelte-check` reports 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)