### PR TITLE
Position Thai tone marks over stacked vowels and tall consonants

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -146,6 +146,24 @@
   }
 }
 
+/* ---- Thai per-code-point letter rendering (shared by TypingFlow + /kitchen-sink).
+   One inline-block box per code point: each paints its own colour, and combining marks
+   are zero-width boxes that overflow back onto their base. Tone marks get a small nudge
+   to clear whatever shares their slot — `toneClass()` in $lib/engine/thai-marks decides
+   which classes apply. The amounts are CSS vars so /kitchen-sink can tune them live. ---- */
+.letter {
+  display: inline-block;
+}
+.letter.tone {
+  transform: translate(var(--tone-x, 0em), var(--tone-y, 0em));
+}
+.letter.tone-raise {
+  --tone-y: var(--tone-raise-y, -0.3em); /* lift clear of an above-vowel / นิคหิต */
+}
+.letter.tone-shift {
+  --tone-x: var(--tone-shift-x, -0.1em); /* nudge left, clear of a tall ascender */
+}
+
 /* Reduced motion is not optional: collapse every animation to a crossfade or
    instant state. */
 @media (prefers-reduced-motion: reduce) {

--- a/apps/web/src/lib/components/TypingFlow.svelte
+++ b/apps/web/src/lib/components/TypingFlow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { CaretStyle } from "$lib/state/settings.svelte"
+  import { toneClass } from "$lib/engine/thai-marks"
 
   let {
     words = [],
@@ -15,16 +16,17 @@
     caretStyle?: CaretStyle
   } = $props()
 
-  // Every word renders one `.letter` box per *code point* (`display: inline-block`),
-  // and the active word colours each box independently — per code point, manoontype
-  // style. Two Thai shaping facts drive the box-per-code-point choice:
+  // Every word renders one `.letter` box per *code point* (`display: inline-block`; see
+  // app.css), and the active word colours each box independently — per code point,
+  // manoontype style. Two Thai shaping facts drive the box-per-code-point choice:
   //   1. A combining mark in its OWN box paints in its own colour; an inline mark would
   //      inherit its base's colour instead, so a wrong vowel could never show red.
   //      Independent boxes → honest per-letter colour and live per-keystroke feedback.
-  //   2. Tone marks (`.tone`, ่ ้ ๊ ๋ ์) need a box to take translateY, which lifts them
-  //      clear of the above-vowel they would otherwise collide with (สิ้น, ที่ in
-  //      Sarabun). See the style block + TONE_RE below.
-  type Cell = { seg: string; cls: string }
+  //   2. Tone marks shaped alone in a box can collide with an above-vowel / นิคหิต / a
+  //      tall ascender; `toneClass()` ($lib/engine/thai-marks) gives them the nudge
+  //      classes (`tone-raise` / `tone-shift`) that app.css translates.
+  // `pos` carries those nudge classes (or "") for each cell.
+  type Cell = { seg: string; cls: string; pos: string }
 
   const PENDING = "text-faint"
   const CURRENT_PENDING = "text-muted"
@@ -32,20 +34,13 @@
   const WRONG =
     "text-danger underline decoration-danger decoration-2 underline-offset-4"
 
-  // Thai tone marks + thanthakhat (่ ้ ๊ ๋ ์). These stack above an above-vowel and, in
-  // a single run, pack tight onto it (สิ้น, ที่ collide). They get the `.tone` class,
-  // which the style block lifts with translateY so they clear the vowel below.
-  const TONE_RE = /[่-์]/ // ่ ้ ๊ ๋ ์
-  function letterCls(seg: string, cls: string): string {
-    return TONE_RE.test(seg) ? `letter tone ${cls}` : `letter ${cls}`
-  }
-
   // Committed and upcoming words only carry a whole-word verdict (the per-word status
   // the drill records), so every code point colours uniformly. One `.letter` box each,
   // same as the active word.
   function staticCells(word: string, done: boolean, correct: boolean): Cell[] {
     const cls = !done ? PENDING : correct ? CORRECT : WRONG
-    return [...word].map((seg) => ({ seg, cls }))
+    const segs = [...word]
+    return segs.map((seg, i) => ({ seg, cls, pos: toneClass(segs, i) }))
   }
 
   const target = $derived(words[currentIdx] ?? "")
@@ -55,22 +50,19 @@
   // it is mistyped, and stays muted until reached. Each `.letter` is its own box, so a
   // mark shows its own colour rather than inheriting its base's (a wrong vowel reds).
   const activeCells = $derived.by<Cell[]>(() => {
-    const out: Cell[] = []
-    let i = 0 // UTF-16 index into target; Thai code points are all single units
-    for (const ch of target) {
-      const end = i + ch.length
+    const segs = [...target] // Thai code points are all single UTF-16 units
+    const out: Cell[] = segs.map((seg, i) => {
       let cls: string
       if (input.length <= i)
         cls = CURRENT_PENDING // not reached yet
-      else if (input.slice(i, end) === ch)
+      else if (input[i] === seg)
         cls = CORRECT // typed correctly
       else cls = WRONG // mistyped
-      out.push({ seg: ch, cls })
-      i = end
-    }
+      return { seg, cls, pos: toneClass(segs, i) }
+    })
     // Keystrokes past the end of the word are surplus errors.
     if (input.length > target.length) {
-      out.push({ seg: input.slice(target.length), cls: WRONG })
+      out.push({ seg: input.slice(target.length), cls: WRONG, pos: "" })
     }
     return out
   })
@@ -256,12 +248,12 @@
           class="word"
           >{#each activeCells as cell, i (i)}<span
               bind:this={activeEls[i]}
-              class={letterCls(cell.seg, cell.cls)}>{cell.seg}</span
+              class="letter {cell.pos} {cell.cls}">{cell.seg}</span
             >{/each}<span bind:this={endEl} class="caret-end" aria-hidden="true"
           ></span></span
         >{:else}{@const correct = statuses[wi] === true}<span class="word"
           >{#each staticCells(word, wi < currentIdx, correct) as cell, i (i)}<span
-              class={letterCls(cell.seg, cell.cls)}>{cell.seg}</span
+              class="letter {cell.pos} {cell.cls}">{cell.seg}</span
             >{/each}</span
         >{/if}{" "}
     {/each}
@@ -280,27 +272,13 @@
     /* Thai has no inter-word spaces, so a bare " " reads as one word. Add a
        little breathing room between tokens. */
     margin-inline: 0.14em;
-    /* A tone mark is inline-block (below); keep a word from breaking at one. */
+    /* Letters are inline-block (.letter, in app.css); keep a word from breaking
+       between them. */
     white-space: nowrap;
   }
 
-  /* One inline-block box per code point. Each box paints in its OWN colour — an inline
-     combining mark instead inherits its base's colour, which defeats per-letter
-     highlighting (a wrong vowel could never show red). The mark glyphs are zero-width
-     and overflow back onto their base, so they still attach; there is no whitespace
-     between letter spans in the markup, so no inter-letter gap; `.word` is
-     `white-space: nowrap` so a word never breaks between boxes. */
-  .letter {
-    display: inline-block;
-  }
-
-  /* Tone marks (่ ้ ๊ ๋ ์) sit above an above-vowel and, in a single run, pack tight
-     onto it (สิ้น, ที่ collide in Sarabun). In their own box they can't stack tight;
-     translateY lifts them clear of the vowel below. (transform needs the inline-block
-     from .letter above — it has no effect on an inline box.) */
-  .letter.tone {
-    transform: translateY(-0.3em);
-  }
+  /* `.letter` and the tone nudges (`.tone` / `.tone-raise` / `.tone-shift`) live in
+     app.css so /kitchen-sink shares them. */
 
   .caret-end {
     display: inline-block;

--- a/apps/web/src/lib/components/TypingFlow.test.ts
+++ b/apps/web/src/lib/components/TypingFlow.test.ts
@@ -71,6 +71,27 @@ describe("TypingFlow", () => {
     expect(cells[2].className).toContain("text-muted"); // า still pending
   });
 
+  it("nudges above marks: tones raise over a vowel/สระอำ; vowels+tones shift left on tall consonants", () => {
+    // [word, cell index, expected char, expect tone-raise?, expect tone-shift?]
+    const cases: [string, number, string, boolean, boolean][] = [
+      ["ทื่อ", 2, "่", true, false], // tone on above-vowel ื -> raise; base ท not tall
+      ["ต่ำ", 1, "่", true, false], // tone before สระอำ (นิคหิต) -> raise; base ต not tall
+      ["ท่อ", 1, "่", false, false], // bare consonant -> natural height
+      ["ปุ่น", 2, "่", false, true], // below-vowel ุ (no raise); base ป tall -> shift
+      ["ฟ้า", 1, "้", false, true], // tone; base ฟ tall -> shift
+      ["ปี่", 1, "ี", false, true], // above-vowel on tall ป -> shift left (no raise)
+      ["ปี่", 2, "่", true, true], // tone: raise (over ี) + shift (ป tall)
+      ["กี่", 1, "ี", false, false], // above-vowel on non-tall ก -> no shift
+    ];
+    for (const [word, idx, ch, raise, shift] of cases) {
+      const { container } = render(TypingFlow, { props: { words: [word], currentIdx: 0, input: "" } });
+      const cell = currentCells(container)[idx];
+      expect(cell.textContent).toBe(ch); // sanity: indexed the intended cell
+      expect(cell.classList.contains("tone-raise")).toBe(raise);
+      expect(cell.classList.contains("tone-shift")).toBe(shift);
+    }
+  });
+
   it("renders the active word's untyped characters as muted", () => {
     const { container } = render(TypingFlow, {
       props: { words: ["นม"], currentIdx: 0, input: "" },

--- a/apps/web/src/lib/engine/thai-marks.ts
+++ b/apps/web/src/lib/engine/thai-marks.ts
@@ -1,0 +1,57 @@
+// Thai mark positioning for the per-code-point `.letter` renderer (see app.css and
+// TypingFlow.svelte). Each code point is its own inline-block box, so a combining mark
+// shaped alone sits at a nominal position that can collide with whatever else occupies
+// the consonant's above slot. These helpers decide the small CSS nudges that fix that.
+
+/** Tone marks + thanthakhat: ่ ้ ๊ ๋ ์ (U+0E48–U+0E4C). */
+export const TONE_RE = /[่-์]/;
+
+/** Above-vowels that sit in the slot a tone would stack onto: ั ิ ี ึ ื ็. */
+const ABOVE_VOWEL_RE = /[ัิ-ื็]/;
+
+/** สระอำ / นิคหิต — their circle sits above the consonant: ำ ํ (follow the tone). */
+const SARA_AM_RE = /[ำํ]/;
+
+/** Any Thai consonant ก–ฮ (U+0E01–U+0E2E). */
+const CONSONANT_RE = /[ก-ฮ]/;
+
+/**
+ * Consonants with a tall right-side ascender: ป ผ ฝ พ ฟ ฬ. A tone sitting over the
+ * consonant's right edge collides with the ascender, so it nudges left to clear it.
+ */
+const TALL_CONSONANT_RE = /[ปผฝพฟฬ]/;
+
+/**
+ * Position-adjustment class(es) for the code point at `segs[i]`, where `segs` is the
+ * word split into one string per code point. Only *above marks* (above-vowels + tone
+ * marks) are ever nudged; everything else returns "". Otherwise returns some combination
+ * of `tone` + `tone-raise` + `tone-shift` (the CSS hooks in app.css).
+ *
+ * - `tone-raise` (tones only): the tone stacks on an above-vowel (ทื่อ, สิ้น) or precedes
+ *   สระอำ (ต่ำ, น้ำ) — lift it so it clears that mark's circle.
+ * - `tone-shift` (any above mark): the base consonant has a tall right ascender
+ *   (ป ผ ฝ พ ฟ ฬ) — the mark sits over the ascender, so nudge it left to clear it.
+ *   The above-vowel AND the tone above a tall consonant both shift by the same amount,
+ *   so they stay aligned (ปี่, ปิ้น, ฟ้า, ปุ่น).
+ * So a tone after a below-vowel on a plain consonant (ปู่... wait ป is tall) — e.g. a
+ * non-tall case like ดู่ — is neither raised nor shifted.
+ */
+export function toneClass(segs: string[], i: number): string {
+  const seg = segs[i];
+  const isTone = TONE_RE.test(seg);
+  if (!isTone && !ABOVE_VOWEL_RE.test(seg)) return ""; // only above marks get nudged
+
+  // raise: a tone stacking on an above-vowel, or one preceding สระอำ. Vowels never raise.
+  const raise =
+    isTone && (ABOVE_VOWEL_RE.test(segs[i - 1] ?? "") || SARA_AM_RE.test(segs[i + 1] ?? ""));
+
+  // shift: base consonant has a tall ascender. The base is the nearest preceding
+  // consonant — vowels/marks between are zero-width and ride over it (e.g. ปุ่น: skip
+  // the below-vowel ุ back to ป).
+  let j = i - 1;
+  while (j >= 0 && !CONSONANT_RE.test(segs[j])) j--;
+  const shift = j >= 0 && TALL_CONSONANT_RE.test(segs[j]);
+
+  if (!raise && !shift) return "";
+  return `tone${raise ? " tone-raise" : ""}${shift ? " tone-shift" : ""}`;
+}

--- a/apps/web/src/routes/kitchen-sink/+page.svelte
+++ b/apps/web/src/routes/kitchen-sink/+page.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { toneClass } from "$lib/engine/thai-marks";
+
+  // A blank canvas for finding Thai mark-rendering exceptions. Type or paste Thai, and
+  // compare the browser's natural shaping against our per-code-point `.letter` boxes
+  // (the renderer TypingFlow uses). Sliders tune the tone raise/shift amounts live so a
+  // good value can be found by eye before baking it into app.css.
+
+  let input = $state(
+    "ทื่อ ท่อ ปุ่น ฝุ่น ต่ำ น้ำ ฟ้า ป่า พ่อ ผ่าน ปี่ สิ้น เรื่อง วุฒิ ปู่ กั่น มื้อ จำนำ"
+  );
+  let size = $state(64); // px
+  let raise = $state(0.3); // em lifted up (matches app default)
+  let shift = $state(0.1); // em nudged left (matches app default)
+  let markNudges = $state(false);
+
+  // Split into lines, then words; render each word's code points as `.letter` boxes.
+  // Keep the inner #each compact so no whitespace text node creeps between letters.
+  const lines = $derived(input.split("\n").map((line) => line.split(" ")));
+
+  function reset() {
+    size = 64;
+    raise = 0.3;
+    shift = 0.1;
+  }
+</script>
+
+<svelte:head><title>Kitchen Sink — Thai letter rendering</title></svelte:head>
+
+<div class="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 p-6">
+  <header class="flex flex-wrap items-baseline gap-x-4 gap-y-1">
+    <h1 class="text-xl font-semibold">Kitchen Sink</h1>
+    <p class="text-muted text-sm">
+      Type or paste Thai. Compare natural shaping vs. the per-letter boxes used by the
+      typing view, and tune the tone nudges.
+    </p>
+  </header>
+
+  <textarea
+    bind:value={input}
+    rows="2"
+    spellcheck="false"
+    class="font-thai border-border bg-bg focus-visible:outline-primary w-full resize-y rounded-lg border p-3 text-lg"
+    placeholder="พิมพ์หรือวางข้อความภาษาไทย…"
+  ></textarea>
+
+  <!-- Controls -->
+  <div class="flex flex-wrap items-center gap-x-8 gap-y-3 text-sm">
+    <label class="flex items-center gap-2">
+      <span class="text-muted w-28">Font size</span>
+      <input type="range" min="24" max="140" step="1" bind:value={size} />
+      <span class="tabular-nums w-14">{size}px</span>
+    </label>
+    <label class="flex items-center gap-2">
+      <span class="text-muted w-28">Tone raise</span>
+      <input type="range" min="0" max="0.6" step="0.01" bind:value={raise} />
+      <span class="tabular-nums w-14">{raise.toFixed(2)}em</span>
+    </label>
+    <label class="flex items-center gap-2">
+      <span class="text-muted w-28">Tone shift ←</span>
+      <input type="range" min="0" max="0.4" step="0.01" bind:value={shift} />
+      <span class="tabular-nums w-14">{shift.toFixed(2)}em</span>
+    </label>
+    <label class="flex items-center gap-2">
+      <input type="checkbox" bind:checked={markNudges} />
+      <span>Mark nudged tones</span>
+    </label>
+    <button class="border-border rounded border px-2 py-1" onclick={reset}>Reset</button>
+  </div>
+
+  <!-- Natural (browser shaping) reference -->
+  <section class="flex flex-col gap-2">
+    <h2 class="text-muted text-xs uppercase tracking-wide">Natural (browser shaping)</h2>
+    <div class="font-thai border-border rounded-lg border p-4 leading-loose" style="font-size:{size}px">
+      {#each lines as line, li (li)}
+        <div>{line.join(" ")}</div>
+      {/each}
+    </div>
+  </section>
+
+  <!-- Letter boxes (app renderer) -->
+  <section class="flex flex-col gap-2">
+    <h2 class="text-muted text-xs uppercase tracking-wide">
+      Letter boxes (typing renderer) — teal = raised, amber = shifted
+    </h2>
+    <div
+      class="font-thai border-border rounded-lg border p-4 leading-loose"
+      class:ks-debug={markNudges}
+      style="font-size:{size}px; --tone-raise-y:{-raise}em; --tone-shift-x:{-shift}em"
+    >
+      {#each lines as line, li (li)}
+        <div>
+          {#each line as word, wi (wi)}{@const segs = [...word]}<span class="ks-word"
+              >{#each segs as seg, i (i)}<span class="letter {toneClass(segs, i)}">{seg}</span
+                >{/each}</span
+            >{/each}
+        </div>
+      {/each}
+    </div>
+  </section>
+</div>
+
+<style>
+  .ks-word {
+    display: inline-block;
+    white-space: nowrap;
+    margin-inline: 0.14em;
+  }
+  /* Debug tint so it's obvious which tones got nudged (and which rule fired). */
+  .ks-debug :global(.letter.tone-raise) {
+    color: var(--primary);
+  }
+  .ks-debug :global(.letter.tone-shift) {
+    color: var(--accent);
+  }
+</style>


### PR DESCRIPTION
Builds on the per-letter Thai highlighting already on `main`. Each code point renders as its own inline-block `.letter` box, so a combining mark shaped alone can collide with whatever shares the consonant's above slot. This PR adds the small positional nudges that fix those collisions, plus a `/kitchen-sink` dev page for finding and tuning more cases.

## What changed

- **`tone-raise`** — lift a tone clear of an above-vowel (ทื่อ, สิ้น) or of สระอำ/นิคหิต whose circle sits in the slot (ต่ำ, น้ำ).
- **`tone-shift`** — nudge above marks **left** on tall-ascender consonants `ป ผ ฝ พ ฟ ฬ` so they clear the ascender (ป่า, ฟ้า, ปุ่น). Applies to the above-vowel **and** the tone by the same amount, so they stay aligned (ปี่, ปิ้น).
- Below-vowels (ปู่) and bare consonants (ท่อ) are left at their natural height.
- Logic extracted to **`$lib/engine/thai-marks.ts`** (`toneClass`), shared by the typing view and the kitchen-sink.
- The `.letter` CSS moved to **`app.css`** (global) with tunable `--tone-raise-y` / `--tone-shift-x` variables (defaults `-0.3em` / `-0.1em`).
- New **`/kitchen-sink`** page: paste/type Thai, compare natural shaping vs. the letter-box renderer side by side, and tune the raise/shift amounts with live sliders ("mark nudged tones" tints raised=teal, shifted=amber).

## Why

In Sarabun, rendering each code point as a separate box means tone marks/vowels sit at a nominal position that overlaps an above-vowel, a สระอำ circle, or a tall consonant's ascender. These nudges reproduce what the font's natural shaping does.

## Reviewer notes

- The shift/raise amounts are CSS variables — `/kitchen-sink` exists specifically to dial them in and surface more exceptions, so the current `-0.3em`/`-0.1em` defaults are easy to revisit.
- Verified on Chromium + Sarabun (the user's setup); the per-mark inline-block approach is browser-shaper-dependent, so a Firefox/Safari spot-check is worthwhile if the support matrix widens.
- Tests: `toneClass` behavior is covered in `TypingFlow.test.ts` (ทื่อ/ต่ำ raise; ปุ่น/ฟ้า shift; ปี่ both; ท่อ/กี่ neither). 67 web tests pass, `svelte-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)